### PR TITLE
chore: auto update Github actions except for unverified ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    ignore:
+      - unverified_script_exec: linz/test-landonline-nr-tag-improver
+      - unverified_script_exec: linz/test-landonline-nr-tag-improver
+      - unverified_script_exec: linz/test-landonline-nr-tag-improver
+      - injection: linz/test-landonline-nr-tag-improver
+      - github_action_from_unverified_creator_used: ad-m/github-push-action
+      - github_action_from_unverified_creator_used: ataylorme/eslint-annotate-action
+      - github_action_from_unverified_creator_used: benc-uk/workflow-dispatch


### PR DESCRIPTION
This pull request is opened automatically by [linz/security-gha-scan](https://github.com/linz/security-gha-scan) to ensure that the usage of Github Actions meets [LINZ security requirements](https://toitutewhenua.atlassian.net/wiki/x/h5SRHQ).

Please review and merge it as soon as possible, contact [#team-step-security](https://linz.enterprise.slack.com/archives/C03278T3HCK) or [#team-step-enablement](https://linz.enterprise.slack.com/archives/CMP0BQ2V7) if you have any question.
